### PR TITLE
Watchdog in Virtual Node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,15 @@ vnode-deploy:
 	@kubectl apply -f $(source_dir)/build-test-tools/deploy/vnode-deploy.yaml
 
 clean-deploy:
-	@kubectl delete deploy kube-watchdog -n kube-system
-	@kubectl delete secrets kube-watchdog kube-watchdog-aadclient -n kube-system
-	@rm ./config
+	@if [ "$(kubectl get deploy kube-watchdog -n kube-system --ignore-not-found)" != "kube-watchdog" ]; then \
+		kubectl delete deploy kube-watchdog -n kube-system;\
+	fi
+	@if [ "$(kubectl delete secrets kube-watchdog -n kube-system --ignore-not-found)" != "kube-watchdog" ]; then \
+		kubectl delete secrets kube-watchdog -n kube-system;\
+	fi
+	@if [ "$(kubectl delete secrets kube-watchdog-aadclient -n kube-system --ignore-not-found)" != "kube-watchdog-aadclient" ]; then \
+		kubectl delete secrets kube-watchdog-aadclient -n kube-system;\
+	fi
+	@if [ -f "$(source_dir)/config" ]; then \
+		rm ./config && exit 1;\
+	fi

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,12 @@ GIT_VAR := $(source_dir)/version.GitCommit
 BUILD_DATE_VAR := $(source_dir)/version.BuildDate
 BUILD_DATE := $$(date +%Y-%m-%d-%H:%M)
 GIT_HASH := $$(git rev-parse --short HEAD)
+VK_CHECK=kubectl get nodes -o jsonpath='{.items[*].metadata.labels.type}'
+
 
 go_build_flags := -buildmode=${GO_BUILD_MODE} -ldflags "-s -X $(VERSION_VAR)=$(VERSION_VAL) -X $(GIT_VAR)=$(GIT_HASH) -X $(BUILD_DATE_VAR)=$(BUILD_DATE)"
 
-.PHONY: clean build
+.PHONY: clean build vnode-deploy
 
 
 build: 
@@ -51,3 +53,37 @@ container:
 	fi
 
 	@docker build $(source_dir) -t "${REGISTRY}:${VERSION}"
+
+vnode-deploy:
+	@if [ -z "${CLIENT_ID}" ]; then \
+		echo "CLIENT_ID must be set to the Service Principal client id" && exit 1;\
+	fi
+	@if [ -z "${CLIENT_PASSWORD}" ]; then \
+		echo "CLIENT_PASSWORD must be set to the Service Principal client secret" && exit 1;\
+	fi
+	@if [ -z "${TENANT_ID}" ]; then \
+		echo "TENANT_ID must be set" && exit 1;\
+	fi
+	@if [ -z "${AKS_NAME}" ]; then \
+		echo "AKS_NAME must be set" && exit 1;\
+	fi
+	@if [ -z "${AKS_GROUP}" ]; then \
+		echo "TENANT_ID must be set" && exit 1;\
+	fi
+	@if [ "$(shell $(VK_CHECK))" != "virtual-kubelet" ]; then \
+		echo "Virtual Node addon must be installed to AKS instance ${AKS_NAME}" && exit 1;\
+	fi
+
+	@az aks get-credentials -n ${AKS_NAME} -g ${AKS_GROUP} -f config
+	@kubectl create secret generic kube-watchdog -n kube-system --from-file=./config
+	@kubectl create secret generic kube-watchdog-aadclient -n kube-system \
+		--from-literal=clientid=${CLIENT_ID} \
+		--from-literal=clientpassword=${CLIENT_PASSWORD} \
+		--from-literal=tenantid=${TENANT_ID}
+	@rm ./config
+	@kubectl apply -f $(source_dir)/build-test-tools/deploy/vnode-deploy.yaml
+
+clean-deploy:
+	@kubectl delete deploy kube-watchdog -n kube-system
+	@kubectl delete secrets kube-watchdog kube-watchdog-aadclient -n kube-system
+	@rm ./config

--- a/README.md
+++ b/README.md
@@ -39,10 +39,22 @@ export TENANT_ID=<AAD directory id>
 export CLIENT_ID=<AKS sp client id>
 export CLIENT_PASSWORD=<AKS sp password>
 ```
+Create a container registry secret. If you are using Azure Container Registry, these instructions will get you there:
+https://docs.microsoft.com/en-us/azure/container-registry/container-registry-auth-aks#access-with-kubernetes-secret
+
+Edit the image and secret name fields in this manifest file `./build-test-tools/deploy/vnode-deploy.yaml`
+
 Deploy Watchdog into AKS Virtual Node instance
 ```
 make vnode-deploy
 ```
+Test by tailing the watchdog logs, running the sample app manifest, and manualy stopping the Azure VM which is running the sample app.
+```
+kubectl logs <kube-watchodog pod name> -f
+kubectl apply -f ./build-test-tools/sample-pvc-app.yaml
+az vm stop -n <vmname> -g <resource group containing the node>
+```
+
 
 ## Deploy as Part of Control Plane
 Use `./build-test-tools/deploy/static-manifest.yaml` as a static manifest (drop in `/etc/kubernetes/manifests/` directory) after you modify `--cloud-provider-init` argument

--- a/README.md
+++ b/README.md
@@ -27,6 +27,23 @@ make container # builds the container image (depends on REGISTRY and VERSION env
 
 # Deploy
 
+## Deploy into Virtual Node
+Follow the steps on this document to turn up an instance of AKS with Virtual Node enabled.
+https://docs.microsoft.com/en-us/azure/aks/virtual-nodes-portal
+
+Export environment variables
+```
+export AKS_GROUP=<Resource Group containing AKS object>
+export AKS_NAME=<AKS name>
+export TENANT_ID=<AAD directory id>
+export CLIENT_ID=<AKS sp client id>
+export CLIENT_PASSWORD=<AKS sp password>
+```
+Deploy Watchdog into AKS Virtual Node instance
+```
+make vnode-deploy
+```
+
 ## Deploy as Part of Control Plane
 Use `./build-test-tools/deploy/static-manifest.yaml` as a static manifest (drop in `/etc/kubernetes/manifests/` directory) after you modify `--cloud-provider-init` argument
 

--- a/build-test-tools/deploy/vnode-deploy.yaml
+++ b/build-test-tools/deploy/vnode-deploy.yaml
@@ -19,7 +19,7 @@ spec:
       hostNetwork: true
       containers:
       - name: "kubernetes-watchdog"
-        image: "njeacr.azurecr.io/kubernetes-watchdog:v0.5"
+        image: "<image repository and tag>" #<--- Edit this, for example: njeacr.azurecr.io/kubernetes-watchdog:v0.5"
         command: ["/usr/bin/kubernetes-watchdog", "run"]
         args: ["--kubeconfig=/etc/kubeconfig/config", "--leader-election-namespace=kube-system", "--cloud-provider=azure", "--cloud-provider-init=client-id:$(CLIENT_ID),client-password:$(CLIENT_PASSWORD),tenant-id:$(TENANT_ID)", "--logtostderr=true"]
         env:
@@ -55,4 +55,4 @@ spec:
       - key: azure.com/aci
         effect: NoSchedule
       imagePullSecrets:
-      - name: acr-auth
+      - name: <image secret for container registry> #<--- Edit this

--- a/build-test-tools/deploy/vnode-deploy.yaml
+++ b/build-test-tools/deploy/vnode-deploy.yaml
@@ -1,0 +1,58 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: "kube-watchdog"
+  namespace: "kube-system"
+  labels:
+    tier: control-plane
+    component: kubernetes-watchdog
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kubernetes-watchdog
+  template:
+    metadata:
+      labels:
+        app: kubernetes-watchdog
+    spec:
+      hostNetwork: true
+      containers:
+      - name: "kubernetes-watchdog"
+        image: "njeacr.azurecr.io/kubernetes-watchdog:v0.5"
+        command: ["/usr/bin/kubernetes-watchdog", "run"]
+        args: ["--kubeconfig=/etc/kubeconfig/config", "--leader-election-namespace=kube-system", "--cloud-provider=azure", "--cloud-provider-init=client-id:$(CLIENT_ID),client-password:$(CLIENT_PASSWORD),tenant-id:$(TENANT_ID)", "--logtostderr=true"]
+        env:
+        - name: CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: kube-watchdog-aadclient
+              key: clientid
+        - name: CLIENT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: kube-watchdog-aadclient
+              key: clientpassword
+        - name: TENANT_ID
+          valueFrom:
+            secretKeyRef:
+              name: kube-watchdog-aadclient
+              key: tenantid
+        volumeMounts:
+        - name: "kubeconfig"
+          mountPath: "/etc/kubeconfig"
+      volumes:
+      - name: "kubeconfig"
+        secret:
+          secretName: "kube-watchdog"
+      nodeSelector:
+        kubernetes.io/role: agent
+        beta.kubernetes.io/os: linux
+        type: virtual-kubelet
+      tolerations:
+      - key: virtual-kubelet.io/provider
+        operator: Exists
+      - key: azure.com/aci
+        effect: NoSchedule
+      imagePullSecrets:
+      - name: acr-auth


### PR DESCRIPTION
I added an example deployment manifest that will run the watchdog in Virtual Node, documentation on how to get it deployed, and a step in the make file to deploy and clean the deploy. 